### PR TITLE
added manager functionality to handle IMU dis- and reconnection

### DIFF
--- a/src/imu_python/__main__.py
+++ b/src/imu_python/__main__.py
@@ -31,13 +31,7 @@ def main(
     sensor_manager.start()
     try:
         while True:
-            data = sensor_manager.get_data()  # Returns IMUData dataclass
-            if data:
-                logger.info(
-                    f"IMU: acc={data.accel.as_array()}, "
-                    f"mag={data.mag.as_array()}, "
-                    f"gyro={data.gyro.as_array()}, "
-                )
+            sensor_manager.log_data()
             time.sleep(1)
     except KeyboardInterrupt:
         logger.info("Stopping...")

--- a/src/imu_python/bno055_imu.py
+++ b/src/imu_python/bno055_imu.py
@@ -18,6 +18,7 @@ class BNO055IMU(IMUBase):
     def initialize(self):
         """Initialize the BNO055 sensor."""
         self.sensor = adafruit_bno055.BNO055_I2C(self.i2c)
+        self.started = True
 
     def acceleration(self) -> VectorXYZ:
         """BNO055 sensor's acceleration information as a VectorXYZ."""

--- a/src/imu_python/imu_base.py
+++ b/src/imu_python/imu_base.py
@@ -11,6 +11,8 @@ from imu_python.base_classes import IMUData, VectorXYZ
 class IMUBase(ABC):
     """Abstract base class for an IMU device."""
 
+    started: bool = False
+
     @abstractmethod
     def initialize(self):
         """Initialize the sensor object."""

--- a/src/imu_python/imu_mock.py
+++ b/src/imu_python/imu_mock.py
@@ -2,36 +2,55 @@
 
 from __future__ import annotations
 
+import random
+
 from imu_python.base_classes import VectorXYZ
 from imu_python.imu_base import IMUBase
 
 
 class FakeIMU(IMUBase):
-    """Mock IMU that returns fixed test values."""
+    """Mock IMU that returns random values."""
 
-    def __init__(
-        self,
-        accel: tuple[float, float, float] = (0.0, 0.0, 0.0),
-        mag: tuple[float, float, float] = (0.0, 0.0, 0.0),
-        gyro: tuple[float, float, float] = (0.0, 0.0, 0.0),
-    ) -> None:
-        self._started = False
-        self._accel = accel
-        self._mag = mag
-        self._gyro = gyro
+    def __init__(self) -> None:
+        self._disconnect = False
+        self._accel = (VectorXYZ.from_tuple((0.0, 0.0, 0.0)),)
+        self._mag = (VectorXYZ.from_tuple((0.0, 0.0, 0.0)),)
+        self._gyro = (VectorXYZ.from_tuple((0.0, 0.0, 0.0)),)
 
     def initialize(self):
         """Initialize the mock IMU."""
-        self._started = True
+        self.started = True
+        self._disconnect = False
 
     def acceleration(self) -> VectorXYZ:
         """Return mock acceleration information."""
-        return VectorXYZ.from_tuple(self._accel)
-
-    def magnetic(self) -> VectorXYZ:
-        """Return mock magnetic information."""
-        return VectorXYZ.from_tuple(self._mag)
+        if self._disconnect:
+            raise OSError(121, "Simulated I2C disconnect")  # errno 121 is EIO on Linux
+        self._accel = self._random_vector()
+        return self._accel
 
     def gyro(self) -> VectorXYZ:
         """Return mock gyro information."""
-        return VectorXYZ.from_tuple(self._gyro)
+        if self._disconnect:
+            raise OSError(121, "Simulated I2C disconnect")  # errno 121 is EIO on Linux
+        self._gyro = self._random_vector()
+        return self._gyro
+
+    def magnetic(self) -> VectorXYZ:
+        """Return mock magnetic information."""
+        if self._disconnect:
+            raise OSError(121, "Simulated I2C disconnect")  # errno 121 is EIO on Linux
+        self._mag = self._random_vector()
+        return self._mag
+
+    @staticmethod
+    def _random_vector() -> VectorXYZ:
+        return VectorXYZ(random.random(), random.random(), random.random())  # noqa: S311
+
+    def disconnect(self):
+        """Simulate IMU disconnection."""
+        self._disconnect = True
+
+    def reconnect(self):
+        """Simulate IMU reconnection."""
+        self._disconnect = False

--- a/src/imu_python/sensor_manager.py
+++ b/src/imu_python/sensor_manager.py
@@ -3,6 +3,8 @@
 import threading
 import time
 
+from loguru import logger
+
 
 class SensorManager:
     """Thread-safe IMU data manager."""
@@ -16,31 +18,63 @@ class SensorManager:
 
     def start(self):
         """Start the sensor manager."""
-        self.imu.initialize()
+        self._initialize_sensor()
         self.running = True
         self.thread = threading.Thread(target=self._loop, daemon=True)
         self.thread.start()
 
     def _loop(self):
         while self.running:
-            data = self.imu.all()
-            with self.lock:
-                self.latest_data = data
+            try:
+                # Attempt to read all sensor data
+                data = self.imu.all()
+                with self.lock:
+                    self.latest_data = data
+
+            except OSError as e:
+                # Catch I2C remote I/O errors
+                self.imu.started = False
+                if e.errno == 121:
+                    logger.error("I2C error detected. Reinitializing sensor...")
+                    time.sleep(1)  # short delay before retry
+                    self._initialize_sensor()
+                else:
+                    # Reraise unexpected errors
+                    raise
+            # Sleep to control streaming rate
             time.sleep(1)
 
     def get_data(self):
         """Return sensor data as a IMUData object."""
+        while self.latest_data is None:
+            time.sleep(0.5)
         with self.lock:
             return self.latest_data
+
+    def log_data(self):
+        """Log sensor data as a IMUData object using loguru."""
+        while self.latest_data is None:
+            time.sleep(0.5)
+        with self.lock:
+            logger.info(
+                f"IMU: acc={self.latest_data.accel.as_array()}, "
+                f"gyro={self.latest_data.gyro.as_array()}, "
+                f"mag={self.latest_data.mag.as_array()}, "
+            )
 
     def stop(self):
         """Stop the background loop and wait for the thread to finish."""
         self.running = False
-
+        self.imu.started = False
         # Wait for thread to exit cleanly
         if self.thread is not None and self.thread.is_alive():
             self.thread.join(timeout=2.0)
 
-        # Let IMU drivers clean up if needed
-        if hasattr(self.imu, "shutdown"):
-            self.imu.shutdown()
+    def _initialize_sensor(self):
+        while self.imu.started is False:
+            try:
+                self.imu.initialize()
+                logger.success("Sensor initialized.")
+            except Exception as init_error:
+                logger.error(f"Failed to initialize sensor: {init_error}")
+                time.sleep(1)

--- a/src/imu_python/st9dof_imu.py
+++ b/src/imu_python/st9dof_imu.py
@@ -21,6 +21,7 @@ class ST9DOFIMU(IMUBase):
         """Initialize the 9-DoF sensor."""
         self.sensor_accel_gyro = LSM6DS(self.i2c)
         self.sensor_mag = LIS3MDL(self.i2c)
+        self.started = True
 
     def acceleration(self) -> VectorXYZ:
         """9-DoF sensor's acceleration information as a VectorXYZ."""


### PR DESCRIPTION
# Summary

- Added manager functionality to handle IMU dis- and reconnection.

- It also works when the IMU is not plugged in when program starts.

- Made the mock IMU return random floats instead of always (0,0,0). This is useful because it mimics the real IMUs and make reconnection functionality easy to test.

- Updated pytest suites to reflect the changes.
- TODO: Auto-detect connection of IMU devices
- TODO: Doc strings of method and classes

---

# Reviewers

## Required Reviewers
- @username1  
- @username2  

## Optional Reviewers
- @username3  
- @username4  

(Feel free to add/remove as needed.)

---

# What Changed?

Describe the main changes in this PR:
-
-
-

---

# Testing

Describe how you verified functionality:

- [ ] Unit tests added
- [ ] Existing tests pass
- [ ] Manual testing performed

**Steps to reproduce/test:**
1.  
2.  
3.  

---

# Code Quality Checklist

Before requesting review, ensure:
- [ ] I ran **`make format`**
- [ ] I ran **`make test`**
- [ ] All CI checks pass
- [ ] Code follows project style & conventions
- [ ] New functions/classes include docstrings
- [ ] Public APIs are typed (type hints)

---

# Documentation

- [ ] Code comments updated
- [ ] README updated (if needed)

---

# Additional Notes

- Anything else reviewers should know?
- Attach outputs, plots, logs, or GIFs here.
