### PR TITLE
Restructure IMU devices from Enum class to dict, populated during import using entry points

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,11 +98,13 @@ make calibrate
 │       ├── __init__.py
 │       ├── __main__.py
 │       ├── base_classes.py
+│       ├── builtin_devices.py
 │       ├── definitions.py
 │       ├── devices.py
 │       ├── factory.py
 │       ├── i2c_bus.py
 │       ├── orientation_filters.py
+│       ├── registry.py
 │       ├── sensor_manager.py
 │       ├── utils.py
 │       └── wrapper.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "imu_python"
-version = "0.1.0"
+version = "0.1.1"
 description = "IMU sensor codes in Python for the exosuit"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,12 @@ no_hw = [
   # For now this can be empty.
 ]
 
+[project.entry-points."imu_module.devices"]
+# register IMU configs
+BNO055 = "imu_python.builtin_devices:BNO055"
+BNO08x = "imu_python.builtin_devices:BNO08x"
+LSM6DSOX_LIS3MDL = "imu_python.builtin_devices:LSM6DSOX_LIS3MDL"
+
 [project.urls]
 homepage = "https://github.com/TUM-Aries-Lab/imu-module"
 

--- a/src/imu_python/builtin_devices.py
+++ b/src/imu_python/builtin_devices.py
@@ -1,0 +1,202 @@
+"""IMUConfig for known supported IMUs.
+
+Current configs: BNO055, BNO08x, LSM6DSOX+LIS3MDL
+"""
+
+from imu_python.base_classes import (
+    IMUConfig,
+    IMUParamNames,
+    IMUSensorTypes,
+    PreConfigStep,
+    PreConfigStepType,
+    SensorConfig,
+)
+from imu_python.definitions import MOCK_NAME, FilterConfig, IMUDeviceID
+
+BNO055 = IMUConfig(
+    devices={
+        IMUDeviceID.IMU0: SensorConfig(
+            name="BNO055",
+            addresses=[0x28, 0x29],
+            library="adafruit_bno055",  # module import path
+            module_class="BNO055_I2C",  # driver class inside the module
+            param_names=IMUParamNames(i2c="i2c", address="address"),
+            pre_config=[
+                # Switch to CONFIG mode
+                PreConfigStep(
+                    name="mode",
+                    args=("CONFIG_MODE",),
+                    step_type=PreConfigStepType.SET,
+                ),
+                # Wait for sensor to switch modes
+                PreConfigStep(
+                    name="time.sleep",
+                    args=(0.025,),
+                    step_type=PreConfigStepType.CALL,
+                ),
+                # Set sensor ranges and bandwidths
+                PreConfigStep(
+                    name="accel_range",
+                    args=("ACCEL_4G",),
+                    step_type=PreConfigStepType.SET,
+                ),
+                PreConfigStep(
+                    name="gyro_range",
+                    args=("GYRO_2000_DPS",),
+                    step_type=PreConfigStepType.SET,
+                ),
+                PreConfigStep(
+                    name="accel_bandwidth",
+                    args=("ACCEL_125HZ",),
+                    step_type=PreConfigStepType.SET,
+                ),
+                PreConfigStep(
+                    name="gyro_bandwidth",
+                    args=("GYRO_116HZ",),
+                    step_type=PreConfigStepType.SET,
+                ),
+                # Wait for settings to take effect
+                PreConfigStep(
+                    name="time.sleep",
+                    args=(0.025,),
+                    step_type=PreConfigStepType.CALL,
+                ),
+                # Switch to AMG mode where accel, gyro and mag are on
+                PreConfigStep(
+                    name="mode",
+                    args=("AMG_MODE",),
+                    step_type=PreConfigStepType.SET,
+                ),
+            ],
+        ),
+    },
+    roles={
+        IMUSensorTypes.accel: IMUDeviceID.IMU0,
+        IMUSensorTypes.gyro: IMUDeviceID.IMU0,
+        IMUSensorTypes.mag: IMUDeviceID.IMU0,
+    },
+    accel_range_g=4.0,
+    gyro_range_dps=2000.0,
+    filter_config=FilterConfig(freq_hz=100.0, gain=0.002250),
+    # Note: Gyro range setting does not actually work on the BNO055
+)
+
+LSM6DSOX_LIS3MDL = IMUConfig(
+    devices={
+        IMUDeviceID.IMU0: SensorConfig(
+            name="LSM6DSOX",
+            addresses=[0x6A, 0x6B],
+            library="adafruit_lsm6ds.lsm6dsox",
+            module_class="LSM6DSOX",
+            param_names=IMUParamNames(i2c="i2c_bus", address="address"),
+            constants_module="adafruit_lsm6ds",
+            pre_config=[
+                PreConfigStep(
+                    name="accelerometer_range",
+                    args=("AccelRange.RANGE_4G",),
+                    step_type=PreConfigStepType.SET,
+                ),
+                PreConfigStep(
+                    name="gyro_range",
+                    args=("GyroRange.RANGE_500_DPS",),
+                    step_type=PreConfigStepType.SET,
+                ),
+                PreConfigStep(
+                    name="accelerometer_data_rate",
+                    args=("Rate.RATE_416_HZ",),
+                    step_type=PreConfigStepType.SET,
+                ),
+                PreConfigStep(
+                    name="gyro_data_rate",
+                    args=("Rate.RATE_416_HZ",),
+                    step_type=PreConfigStepType.SET,
+                ),
+            ],
+        ),
+        IMUDeviceID.IMU1: SensorConfig(
+            name="LIS3MDL",
+            addresses=[0x1C, 0x1E],
+            library="adafruit_lis3mdl",
+            module_class="LIS3MDL",
+            param_names=IMUParamNames(i2c="i2c_bus", address="address"),
+            pre_config=[
+                PreConfigStep(
+                    name="range",
+                    args=("Range.RANGE_4_GAUSS",),
+                    step_type=PreConfigStepType.SET,
+                ),
+                PreConfigStep(
+                    name="data_rate",
+                    args=("Rate.RATE_40_HZ",),
+                    step_type=PreConfigStepType.SET,
+                ),
+            ],
+        ),
+    },
+    roles={
+        IMUSensorTypes.accel: IMUDeviceID.IMU0,
+        IMUSensorTypes.gyro: IMUDeviceID.IMU0,
+        IMUSensorTypes.mag: IMUDeviceID.IMU1,
+    },
+    accel_range_g=4.0,
+    gyro_range_dps=500.0,
+    filter_config=FilterConfig(freq_hz=104.0, gain=0.000573),
+)
+
+BNO08x = IMUConfig(
+    devices={
+        IMUDeviceID.IMU0: SensorConfig(
+            name="BNO08x",
+            addresses=[0x4A, 0x4B],
+            library="adafruit_bno08x.i2c",
+            module_class="BNO08X_I2C",
+            param_names=IMUParamNames(i2c="i2c_bus", address="address"),
+            constants_module="adafruit_bno08x",
+            pre_config=[
+                PreConfigStep(
+                    name="enable_feature",
+                    args=("BNO_REPORT_ACCELEROMETER", 10000),
+                    step_type=PreConfigStepType.CALL,
+                ),
+                PreConfigStep(
+                    name="enable_feature",
+                    args=("BNO_REPORT_GYROSCOPE", 10000),
+                    step_type=PreConfigStepType.CALL,
+                ),
+                PreConfigStep(
+                    name="enable_feature",
+                    args=("BNO_REPORT_MAGNETOMETER",),
+                    step_type=PreConfigStepType.CALL,
+                ),
+            ],
+        ),
+    },
+    roles={
+        IMUSensorTypes.accel: IMUDeviceID.IMU0,
+        IMUSensorTypes.gyro: IMUDeviceID.IMU0,
+        IMUSensorTypes.mag: IMUDeviceID.IMU0,
+    },
+    accel_range_g=8.0,  # default 8g, not settable in driver
+    gyro_range_dps=2000.0,  # default 2000dps, not settable in driver
+    filter_config=FilterConfig(
+        freq_hz=20.0, gain=0.001538
+    ),  # 50 ms update interval by default
+)
+
+MOCK = IMUConfig(
+    devices={
+        IMUDeviceID.IMU0: SensorConfig(
+            name=MOCK_NAME,
+            addresses=[0x00, 0x01],  # fake I2C addresses for testing
+            library="imu_python.base_classes",  # module path (corrected)
+            module_class="AdafruitIMU",  # driver class
+            param_names=IMUParamNames(i2c="i2c", address="address"),
+        ),
+    },
+    roles={
+        IMUSensorTypes.accel: IMUDeviceID.IMU0,
+        IMUSensorTypes.gyro: IMUDeviceID.IMU0,
+    },
+    accel_range_g=8.0,
+    gyro_range_dps=2000.0,
+)

--- a/src/imu_python/definitions.py
+++ b/src/imu_python/definitions.py
@@ -86,6 +86,8 @@ DEFAULT_LOG_FILENAME = "log_file"
 
 I2C_ERROR = EREMOTEIO
 
+MOCK_NAME = "MOCK"
+
 
 @dataclass
 class IMUUpdateTime:

--- a/src/imu_python/devices.py
+++ b/src/imu_python/devices.py
@@ -1,296 +1,106 @@
 """Enum registry of IMU device configurations."""
 
 from dataclasses import replace
-from enum import Enum
 
 from loguru import logger
 
 from imu_python.base_classes import (
     IMUConfig,
-    IMUParamNames,
-    IMUSensorTypes,
-    PreConfigStep,
-    PreConfigStepType,
-    SensorConfig,
 )
-from imu_python.definitions import FilterConfig, IMUDescriptor, IMUDeviceID
+from imu_python.definitions import MOCK_NAME, IMUDescriptor
+from imu_python.registry import IMU_DEVICES
 
 
-class IMUDevices(Enum):
-    """Enumeration containing configuration for all supported IMU devices."""
+def get_mock() -> tuple[str, IMUConfig]:
+    """Return a MOCK IMU with name and IMUConfig.
 
-    BNO055 = IMUConfig(
-        devices={
-            IMUDeviceID.IMU0: SensorConfig(
-                name="BNO055",
-                addresses=[0x28, 0x29],
-                library="adafruit_bno055",  # module import path
-                module_class="BNO055_I2C",  # driver class inside the module
-                param_names=IMUParamNames(i2c="i2c", address="address"),
-                pre_config=[
-                    # Switch to CONFIG mode
-                    PreConfigStep(
-                        name="mode",
-                        args=("CONFIG_MODE",),
-                        step_type=PreConfigStepType.SET,
-                    ),
-                    # Wait for sensor to switch modes
-                    PreConfigStep(
-                        name="time.sleep",
-                        args=(0.025,),
-                        step_type=PreConfigStepType.CALL,
-                    ),
-                    # Set sensor ranges and bandwidths
-                    PreConfigStep(
-                        name="accel_range",
-                        args=("ACCEL_4G",),
-                        step_type=PreConfigStepType.SET,
-                    ),
-                    PreConfigStep(
-                        name="gyro_range",
-                        args=("GYRO_2000_DPS",),
-                        step_type=PreConfigStepType.SET,
-                    ),
-                    PreConfigStep(
-                        name="accel_bandwidth",
-                        args=("ACCEL_125HZ",),
-                        step_type=PreConfigStepType.SET,
-                    ),
-                    PreConfigStep(
-                        name="gyro_bandwidth",
-                        args=("GYRO_116HZ",),
-                        step_type=PreConfigStepType.SET,
-                    ),
-                    # Wait for settings to take effect
-                    PreConfigStep(
-                        name="time.sleep",
-                        args=(0.025,),
-                        step_type=PreConfigStepType.CALL,
-                    ),
-                    # Switch to AMG mode where accel, gyro and mag are on
-                    PreConfigStep(
-                        name="mode",
-                        args=("AMG_MODE",),
-                        step_type=PreConfigStepType.SET,
-                    ),
-                ],
-            ),
-        },
-        roles={
-            IMUSensorTypes.accel: IMUDeviceID.IMU0,
-            IMUSensorTypes.gyro: IMUDeviceID.IMU0,
-            IMUSensorTypes.mag: IMUDeviceID.IMU0,
-        },
-        accel_range_g=4.0,
-        gyro_range_dps=2000.0,
-        filter_config=FilterConfig(freq_hz=100.0, gain=0.002250),
-        # Note: Gyro range setting does not actually work on the BNO055
-    )
+    :return: tuple with the name and IMUConfig of the MOCK IMU.
+    """
+    mock_name = MOCK_NAME
+    try:
+        return mock_name, IMU_DEVICES[mock_name]
+    except KeyError:
+        raise
 
-    LSM6DSOX_LIS3MDL = IMUConfig(
-        devices={
-            IMUDeviceID.IMU0: SensorConfig(
-                name="LSM6DSOX",
-                addresses=[0x6A, 0x6B],
-                library="adafruit_lsm6ds.lsm6dsox",
-                module_class="LSM6DSOX",
-                param_names=IMUParamNames(i2c="i2c_bus", address="address"),
-                constants_module="adafruit_lsm6ds",
-                pre_config=[
-                    PreConfigStep(
-                        name="accelerometer_range",
-                        args=("AccelRange.RANGE_4G",),
-                        step_type=PreConfigStepType.SET,
-                    ),
-                    PreConfigStep(
-                        name="gyro_range",
-                        args=("GyroRange.RANGE_500_DPS",),
-                        step_type=PreConfigStepType.SET,
-                    ),
-                    PreConfigStep(
-                        name="accelerometer_data_rate",
-                        args=("Rate.RATE_416_HZ",),
-                        step_type=PreConfigStepType.SET,
-                    ),
-                    PreConfigStep(
-                        name="gyro_data_rate",
-                        args=("Rate.RATE_416_HZ",),
-                        step_type=PreConfigStepType.SET,
-                    ),
-                ],
-            ),
-            IMUDeviceID.IMU1: SensorConfig(
-                name="LIS3MDL",
-                addresses=[0x1C, 0x1E],
-                library="adafruit_lis3mdl",
-                module_class="LIS3MDL",
-                param_names=IMUParamNames(i2c="i2c_bus", address="address"),
-                pre_config=[
-                    PreConfigStep(
-                        name="range",
-                        args=("Range.RANGE_4_GAUSS",),
-                        step_type=PreConfigStepType.SET,
-                    ),
-                    PreConfigStep(
-                        name="data_rate",
-                        args=("Rate.RATE_40_HZ",),
-                        step_type=PreConfigStepType.SET,
-                    ),
-                ],
-            ),
-        },
-        roles={
-            IMUSensorTypes.accel: IMUDeviceID.IMU0,
-            IMUSensorTypes.gyro: IMUDeviceID.IMU0,
-            IMUSensorTypes.mag: IMUDeviceID.IMU1,
-        },
-        accel_range_g=4.0,
-        gyro_range_dps=500.0,
-        filter_config=FilterConfig(freq_hz=104.0, gain=0.000573),
-    )
 
-    BNO08x = IMUConfig(
-        devices={
-            IMUDeviceID.IMU0: SensorConfig(
-                name="BNO08x",
-                addresses=[0x4A, 0x4B],
-                library="adafruit_bno08x.i2c",
-                module_class="BNO08X_I2C",
-                param_names=IMUParamNames(i2c="i2c_bus", address="address"),
-                constants_module="adafruit_bno08x",
-                pre_config=[
-                    PreConfigStep(
-                        name="enable_feature",
-                        args=("BNO_REPORT_ACCELEROMETER", 10000),
-                        step_type=PreConfigStepType.CALL,
-                    ),
-                    PreConfigStep(
-                        name="enable_feature",
-                        args=("BNO_REPORT_GYROSCOPE", 10000),
-                        step_type=PreConfigStepType.CALL,
-                    ),
-                    PreConfigStep(
-                        name="enable_feature",
-                        args=("BNO_REPORT_MAGNETOMETER",),
-                        step_type=PreConfigStepType.CALL,
-                    ),
-                ],
-            ),
-        },
-        roles={
-            IMUSensorTypes.accel: IMUDeviceID.IMU0,
-            IMUSensorTypes.gyro: IMUDeviceID.IMU0,
-            IMUSensorTypes.mag: IMUDeviceID.IMU0,
-        },
-        accel_range_g=8.0,  # default 8g, not settable in driver
-        gyro_range_dps=2000.0,  # default 2000dps, not settable in driver
-        filter_config=FilterConfig(
-            freq_hz=20.0, gain=0.001538
-        ),  # 50 ms update interval by default
-    )
+def _from_address(addr: int) -> tuple[IMUDescriptor, IMUConfig] | None:
+    """Return a tuple containing IMU anchor information and IMU config based on the given address, or None if unknown.
 
-    MOCK = IMUConfig(
-        devices={
-            IMUDeviceID.IMU0: SensorConfig(
-                name="MOCK",
-                addresses=[0x00, 0x01],  # fake I2C addresses for testing
-                library="imu_python.base_classes",  # module path (corrected)
-                module_class="AdafruitIMU",  # driver class
-                param_names=IMUParamNames(i2c="i2c", address="address"),
-            ),
-        },
-        roles={
-            IMUSensorTypes.accel: IMUDeviceID.IMU0,
-            IMUSensorTypes.gyro: IMUDeviceID.IMU0,
-        },
-        accel_range_g=8.0,
-        gyro_range_dps=2000.0,
-    )
+    :param addr: I2C address of the device
+    :return: Information of the IMU (IMUDescriptor, IMUConfig) of the matched device or None
+    """
+    for device in IMU_DEVICES:
+        base_config = IMU_DEVICES[device]
 
-    @property
-    def config(self) -> IMUConfig:
-        """Return the IMUConfig stored inside the enum member."""
-        return self.value
-
-    @staticmethod
-    def _from_address(addr: int) -> tuple[IMUDescriptor, IMUConfig] | None:
-        """Return a tuple containing IMU anchor information and IMU config based on the given address, or None if unknown.
-
-        :param addr: I2C address of the device
-        :return: Information of the IMU (IMUDescriptor, IMUConfig) of the matched device or None
-        """
-        for device in IMUDevices:
-            base_config: IMUConfig = device.value
-
-            for dev_id, sensor_cfg in base_config.devices.items():
-                if addr not in sensor_cfg.addresses:
-                    continue
-
-                # Compute instance index to be addr index
-                instance_idx = sensor_cfg.addresses.index(addr)
-                # narrow down to a single address
-                narrowed_sensor = replace(sensor_cfg, addresses=[addr])
-                # narrow down the device dict to contain only this device
-                devices = {dev_id: narrowed_sensor}
-                # narrow down the role dict to contain only this device
-                roles = {
-                    role: target
-                    for role, target in base_config.roles.items()
-                    if target == dev_id
-                }
-                # combine the changes
-                partial_config = replace(
-                    base_config,
-                    devices=devices,
-                    roles=roles,
-                )
-
-                # anchor = device name and index of the address in address list
-                key = IMUDescriptor(name=device.name, index=instance_idx)
-
-                logger.trace(
-                    f"Address 0x{addr:02X} matched to device {device.name} index {instance_idx}"
-                )
-                return key, partial_config
-
-        return None
-
-    @staticmethod
-    def get_config(addresses: list[int]) -> dict[IMUDescriptor, IMUConfig]:
-        """Return a dictionary mapping imu name and device index to IMU Configs based on a list of addresses.
-
-        The device index is the same as its address index on the address list, which is used to distinguish between multiple IMU devices of the same model.
-        It is assumed that a split IMU has either high or low addresses across all of its devices. i.e.
-        LSM6DSOX+LIS3MDL has the addresses 0x6A and 0x1C or 0x6B and 0x1E.
-
-        :param addresses: list of detected addresses
-        :return: A dictionary of IMUDescriptor as keys and IMUConfigs as values.
-        """
-        detected: dict[IMUDescriptor, IMUConfig] = {}
-
-        for addr in addresses:
-            result = IMUDevices._from_address(addr)
-            if not result:
+        for dev_id, sensor_cfg in base_config.devices.items():
+            if addr not in sensor_cfg.addresses:
                 continue
 
-            key, partial = result
+            # Compute instance index to be addr index
+            instance_idx = sensor_cfg.addresses.index(addr)
+            # narrow down to a single address
+            narrowed_sensor = replace(sensor_cfg, addresses=[addr])
+            # narrow down the device dict to contain only this device
+            devices = {dev_id: narrowed_sensor}
+            # narrow down the role dict to contain only this device
+            roles = {
+                role: target
+                for role, target in base_config.roles.items()
+                if target == dev_id
+            }
+            # combine the changes
+            partial_config = replace(
+                base_config,
+                devices=devices,
+                roles=roles,
+            )
 
-            if key not in detected:
-                detected[key] = partial
-            else:
-                # merge partial IMUConfigs if devices belong to the same IMU
-                base = detected[key]
-                # add this device to the device list of IMUConfig with the same key
-                merged_devices = dict(base.devices)
-                merged_devices.update(partial.devices)
-                # update roles to include roles of this device
-                merged_roles = dict(base.roles)
-                merged_roles.update(partial.roles)
-                # update IMUConfig
-                detected[key] = replace(
-                    base,
-                    devices=merged_devices,
-                    roles=merged_roles,
-                )
+            # anchor = device name and index of the address in address list
+            key = IMUDescriptor(name=device, index=instance_idx)
 
-        return detected
+            logger.trace(
+                f"Address 0x{addr:02X} matched to device {device} index {instance_idx}"
+            )
+            return key, partial_config
+
+    return None
+
+
+def get_config(addresses: list[int]) -> dict[IMUDescriptor, IMUConfig]:
+    """Return a dictionary mapping imu name and device index to IMU Configs based on a list of addresses.
+
+    The device index is the same as its address index on the address list, which is used to distinguish between multiple IMU devices of the same model.
+    It is assumed that a split IMU has either high or low addresses across all of its devices. i.e.
+    LSM6DSOX+LIS3MDL has the addresses 0x6A and 0x1C or 0x6B and 0x1E.
+
+    :param addresses: list of detected addresses
+    :return: A dictionary of IMUDescriptor as keys and IMUConfigs as values.
+    """
+    detected: dict[IMUDescriptor, IMUConfig] = {}
+
+    for addr in addresses:
+        result = _from_address(addr)
+        if not result:
+            continue
+
+        key, partial = result
+
+        if key not in detected:
+            detected[key] = partial
+        else:
+            # merge partial IMUConfigs if devices belong to the same IMU
+            base = detected[key]
+            # add this device to the device list of IMUConfig with the same key
+            merged_devices = dict(base.devices)
+            merged_devices.update(partial.devices)
+            # update roles to include roles of this device
+            merged_roles = dict(base.roles)
+            merged_roles.update(partial.roles)
+            # update IMUConfig
+            detected[key] = replace(
+                base,
+                devices=merged_devices,
+                roles=merged_roles,
+            )
+
+    return detected

--- a/src/imu_python/factory.py
+++ b/src/imu_python/factory.py
@@ -5,8 +5,9 @@ from typing import Any
 
 from loguru import logger
 
+from imu_python.builtin_devices import MOCK
 from imu_python.definitions import CORE_COUNT, GIL_ENABLED, I2CBusID
-from imu_python.devices import IMUDevices
+from imu_python.devices import get_config
 from imu_python.i2c_bus import I2CBusDescriptor, JetsonBus
 from imu_python.sensor_manager import IMUManager
 from imu_python.wrapper import IMUWrapper
@@ -77,7 +78,7 @@ class IMUFactory:
 
         addresses = IMUFactory.scan_i2c_bus(i2c=i2c_bus)
 
-        detected_configs = IMUDevices.get_config(addresses=addresses)
+        detected_configs = get_config(addresses=addresses)
 
         for imu_descriptor, cfg in detected_configs.items():
             imu_wrapper = IMUWrapper(
@@ -115,9 +116,5 @@ class IMUFactory:
             i2c.unlock()
             return addresses
         except Exception as err:
-            logger.warning(
-                f"I2C scan failed: {err}. Returning {IMUDevices.MOCK.config} addresses."
-            )
-            return [
-                a for d in IMUDevices.MOCK.config.devices.values() for a in d.addresses
-            ]
+            logger.warning(f"I2C scan failed: {err}. Returning {MOCK} addresses.")
+            return [a for d in MOCK.devices.values() for a in d.addresses]

--- a/src/imu_python/registry.py
+++ b/src/imu_python/registry.py
@@ -1,0 +1,42 @@
+"""Registry for device entry points."""
+
+from importlib.metadata import entry_points
+
+from loguru import logger
+
+from imu_python.base_classes import IMUConfig
+from imu_python.builtin_devices import MOCK
+from imu_python.definitions import MOCK_NAME
+
+IMU_DEVICES: dict[str, IMUConfig] = {}
+
+
+def _load_registry() -> dict[str, IMUConfig]:
+    registry = {}
+
+    registry[MOCK_NAME] = MOCK
+
+    for ep in entry_points(group="imu_module.devices"):
+        config: IMUConfig = ep.load()
+        registry[ep.name] = config
+        logger.info(f"loaded IMU config {ep.name}")
+
+    for ep in entry_points(group="imu_module.device_overrides"):
+        registry[ep.name] = ep.load()
+        logger.info(f"overrode IMU config {ep.name}")
+
+    return registry
+
+
+def reload_registry() -> None:
+    """Reload all registered IMU devices and overrides.
+
+    Call this after installing or uninstalling packages that register
+    devices, or to pick up changes to override configs without restarting.
+    """
+    IMU_DEVICES.clear()
+    IMU_DEVICES.update(_load_registry())
+
+
+# Build registry at import time
+reload_registry()

--- a/src/imu_python/registry.py
+++ b/src/imu_python/registry.py
@@ -31,8 +31,8 @@ def _load_registry() -> dict[str, IMUConfig]:
 def reload_registry() -> None:
     """Reload all registered IMU devices and overrides.
 
-    Call this after installing or uninstalling packages that register
-    devices, or to pick up changes to override configs without restarting.
+    IMU config changes are applied only during init time.
+    :return: None
     """
     IMU_DEVICES.clear()
     IMU_DEVICES.update(_load_registry())

--- a/tests/devices_test.py
+++ b/tests/devices_test.py
@@ -5,14 +5,14 @@ from unittest.mock import patch
 import pytest
 
 from imu_python.base_classes import IMUConfig, IMUSensorTypes
-from imu_python.definitions import IMUDescriptor, IMUDeviceID
-from imu_python.devices import IMUDevices
+from imu_python.definitions import MOCK_NAME, IMUDescriptor, IMUDeviceID
+from imu_python.devices import IMU_DEVICES, _from_address, get_config
 
 
 def test_device_addresses() -> None:
     """Test the IMU device addresses."""
-    for device in IMUDevices:
-        assert (len(a.addresses) == 2 for a in device.config.devices.values())
+    for device in IMU_DEVICES:
+        assert (len(a.addresses) == 2 for a in IMU_DEVICES[device].devices.values())
 
 
 def test_device_from_bad_address() -> None:
@@ -21,7 +21,7 @@ def test_device_from_bad_address() -> None:
     invalid_addr = 0xAA
 
     # Act
-    config = IMUDevices._from_address(addr=invalid_addr)
+    config = _from_address(addr=invalid_addr)
 
     # Assert
     assert config is None
@@ -29,12 +29,12 @@ def test_device_from_bad_address() -> None:
 
 @pytest.mark.parametrize(
     "valid_address",
-    [addr for dev in IMUDevices.MOCK.config.devices.values() for addr in dev.addresses],
+    [addr for dev in IMU_DEVICES[MOCK_NAME].devices.values() for addr in dev.addresses],
 )
 def test_device_from_valid_address(valid_address: int) -> None:
     """Test the IMU device addresses."""
     # Act
-    imu_info = IMUDevices._from_address(addr=valid_address)
+    imu_info = _from_address(addr=valid_address)
 
     # Assert
     assert imu_info is not None
@@ -49,7 +49,7 @@ def test_merge_partial_configs() -> None:
 
     # Build a mutated MOCK config with a second device that shares
     # the same address index (1) for its address list so merging occurs.
-    config = IMUDevices.MOCK.config
+    config = IMU_DEVICES[MOCK_NAME]
     imu0_sensor = config.devices[IMUDeviceID.IMU0]
     # create a second sensor with a different address pair
     imu1_sensor = replace(imu0_sensor, name=IMUDeviceID.IMU1, addresses=[0x10, 0x11])
@@ -59,11 +59,11 @@ def test_merge_partial_configs() -> None:
     mutated_config.roles.update({IMUSensorTypes.mag: IMUDeviceID.IMU1})
 
     # Patch the MOCK member so that there are two devices in MOCK
-    with patch.object(IMUDevices.MOCK, "_value_", mutated_config):
+    with patch.dict(IMU_DEVICES, {MOCK_NAME: mutated_config}):
         # Choose addresses that map to index 1 in both device address lists
-        detected = IMUDevices.get_config([0x01, 0x11])
+        detected = get_config([0x01, 0x11])
 
-    dsc = IMUDescriptor(name=IMUDevices.MOCK.name, index=1)
+    dsc = IMUDescriptor(MOCK_NAME, index=1)
     cfg = detected[dsc]
     assert dsc in detected
     assert isinstance(cfg, IMUConfig)

--- a/tests/factory_test.py
+++ b/tests/factory_test.py
@@ -1,13 +1,13 @@
 """Test the IMUFactory class."""
 
-from src.imu_python.devices import IMUDevices
+from src.imu_python.devices import IMU_DEVICES, get_mock
 from src.imu_python.factory import IMUFactory
 
 
 def test_imu_factory() -> None:
     """Test the IMUFactory class."""
     # Arrange
-    mock_imu_name = IMUDevices.MOCK.name
+    mock_imu_name, mock_imu_config = get_mock()
 
     # Act
     imu_managers = IMUFactory.detect_and_create()
@@ -32,4 +32,5 @@ def test_imu_factory() -> None:
                 getattr(device, attr_name, None)
 
         # check that config matches the expected IMU name
-        assert mock_imu_name in IMUDevices.__members__
+        assert mock_imu_name in IMU_DEVICES
+        assert mock_imu_config == IMU_DEVICES[mock_imu_name]

--- a/tests/registry_test.py
+++ b/tests/registry_test.py
@@ -1,0 +1,46 @@
+"""Tests for the device registry loading and overriding mechanism."""
+
+from dataclasses import replace
+from importlib.metadata import EntryPoint
+from unittest.mock import MagicMock, patch
+
+from imu_python.base_classes import IMUConfig
+from imu_python.builtin_devices import MOCK
+from imu_python.definitions import MOCK_NAME
+from imu_python.registry import _load_registry
+
+
+def test_builtin_devices_are_loaded():
+    """Test that the built-in devices are loaded into the registry."""
+    registry = _load_registry()
+    assert len(registry) > 0
+    for name, config in registry.items():
+        assert isinstance(config, IMUConfig), f"{name} did not load as IMUConfig"
+
+
+def test_known_builtin_present():
+    """Test that known built-in devices are present in the registry."""
+    registry = _load_registry()
+    assert MOCK_NAME in registry
+
+
+def test_override_replaces_builtin():
+    """Test that device overrides replace built-in devices."""
+    builtin_mock_config = MOCK
+    modified = replace(builtin_mock_config, accel_range_g=16.0)
+
+    mock_override = MagicMock(spec=EntryPoint)
+    mock_override.name = MOCK_NAME
+    mock_override.load.return_value = modified
+
+    with patch("imu_python.registry.entry_points") as mock_ep:
+        mock_ep.side_effect = lambda group: (
+            []
+            if group == "imu_module.devices"
+            else [mock_override]
+            if group == "imu_module.device_overrides"
+            else []
+        )
+        registry = _load_registry()
+
+    assert registry[MOCK_NAME].accel_range_g == 16.0

--- a/tests/sensor_manager_test.py
+++ b/tests/sensor_manager_test.py
@@ -6,7 +6,7 @@ import time
 import pytest
 
 from imu_python.definitions import IMUDescriptor, IMUDeviceID
-from imu_python.devices import IMUDevices
+from imu_python.devices import get_mock
 from imu_python.i2c_bus import I2CBusDescriptor
 from imu_python.sensor_manager import IMUManager
 from imu_python.wrapper import IMUWrapper
@@ -14,15 +14,16 @@ from imu_python.wrapper import IMUWrapper
 
 @pytest.fixture
 def imu_setup() -> IMUManager:
-    """Fixture providing sensor_manager for tests."""
+    """Fixture providing manager for tests."""
+    name, config = get_mock()
     wrapper = IMUWrapper(
-        config=IMUDevices.MOCK.config,
-        imu_descriptor=IMUDescriptor(name="MOCK", index=0),
+        config=config,
+        imu_descriptor=IMUDescriptor(name=name, index=0),
         i2c_bus_descriptor=I2CBusDescriptor(None, None),
     )
     lock = threading.Lock()
-    sensor_manager = IMUManager(imu_wrapper=wrapper, i2c_lock=lock)
-    return sensor_manager
+    manager = IMUManager(imu_wrapper=wrapper, i2c_lock=lock)
+    return manager
 
 
 def test_manager_get_data(imu_setup: IMUManager) -> None:
@@ -95,9 +96,10 @@ def test_manager_records_data() -> None:
     # Arrange
     from unittest.mock import MagicMock, patch
 
+    name, config = get_mock()
     wrapper = IMUWrapper(
-        config=IMUDevices.MOCK.config,
-        imu_descriptor=IMUDescriptor(name="MOCK", index=0),
+        config=config,
+        imu_descriptor=IMUDescriptor(name=name, index=0),
         i2c_bus_descriptor=I2CBusDescriptor(None, None),
     )
     mock_writer = MagicMock()

--- a/tests/wrapper_test.py
+++ b/tests/wrapper_test.py
@@ -1,6 +1,5 @@
 """Test the factory and manager for the imu sensor objects."""
 
-import copy
 from dataclasses import replace
 from unittest.mock import MagicMock, patch
 
@@ -16,7 +15,7 @@ from imu_python.base_classes import (
 )
 from imu_python.calibration.mag_calibration import apply_mag_cal
 from imu_python.definitions import IMUDescriptor, IMUDeviceID
-from imu_python.devices import IMUDevices
+from imu_python.devices import get_mock
 from imu_python.i2c_bus import I2CBusDescriptor
 from imu_python.wrapper import IMUWrapper
 
@@ -36,34 +35,37 @@ def mutate_sensor(
     return replace(cfg, devices=new_devices)
 
 
-def test_imu_wrapper() -> None:
-    """Test the imu wrapper class."""
-    # Arrange
-    config = IMUDevices.MOCK.config
+@pytest.fixture
+def wrapper_setup() -> IMUWrapper:
+    """Fixture providing wrapper for tests."""
+    name, config = get_mock()
 
-    # Act
     wrapper = IMUWrapper(
         config=config,
-        imu_descriptor=IMUDescriptor(name="MOCK", index=0),
+        imu_descriptor=IMUDescriptor(name=name, index=0),
         i2c_bus_descriptor=I2CBusDescriptor(None, None),
     )
+    return wrapper
+
+
+def test_imu_wrapper(wrapper_setup: IMUWrapper) -> None:
+    """Test the imu wrapper class."""
+    # Arrange
+    wrapper = wrapper_setup
+
+    # Act
     wrapper.reload()
 
     # Assert
     assert wrapper.started
 
 
-def test_imu_wrapper_attr_with_no_role() -> None:
+def test_imu_wrapper_attr_with_no_role(wrapper_setup: IMUWrapper) -> None:
     """Test the imu wrapper class read attribute with no role."""
     # Arrange
-    config = IMUDevices.MOCK.config
+    wrapper = wrapper_setup
 
     # Act
-    wrapper = IMUWrapper(
-        config=config,
-        imu_descriptor=IMUDescriptor(name="MOCK", index=0),
-        i2c_bus_descriptor=I2CBusDescriptor(None, None),
-    )
     wrapper.reload()
 
     assert wrapper.read_sensor(IMUSensorTypes.mag) is None
@@ -72,13 +74,13 @@ def test_imu_wrapper_attr_with_no_role() -> None:
 def test_imu_wrapper_attr_with_no_device() -> None:
     """Test the imu wrapper class read attribute with no device."""
     # Arrange
-    config = IMUDevices.MOCK.config
+    name, config = get_mock()
     config.roles.update({IMUSensorTypes.mag: IMUDeviceID.IMU1})
 
     # Act
     wrapper = IMUWrapper(
         config=config,
-        imu_descriptor=IMUDescriptor(name="MOCK", index=0),
+        imu_descriptor=IMUDescriptor(name=name, index=0),
         i2c_bus_descriptor=I2CBusDescriptor(None, None),
     )
     wrapper.reload()
@@ -212,12 +214,12 @@ def test_imu_wrapper_attr_with_no_device() -> None:
 )
 def test_imu_wrapper_reload_fails(reason, mutate_config):
     """Test if wrapper raises runtime error with bad IMU Configs."""
-    config = copy.deepcopy(IMUDevices.MOCK.config)
+    name, config = get_mock()
     config = mutate_config(config)
 
     wrapper = IMUWrapper(
         config=config,
-        imu_descriptor=IMUDescriptor(name="MOCK", index=0),
+        imu_descriptor=IMUDescriptor(name=name, index=0),
         i2c_bus_descriptor=I2CBusDescriptor(None, None),
     )
 
@@ -228,7 +230,7 @@ def test_imu_wrapper_reload_fails(reason, mutate_config):
 def test_pre_config_with_mock() -> None:
     """Test if the IMU is pre-configured properly with mock."""
     # Arrange
-    config = IMUDevices.MOCK.config
+    name, config = get_mock()
     config = mutate_sensor(
         cfg=config,
         device_id=IMUDeviceID.IMU0,
@@ -259,7 +261,7 @@ def test_pre_config_with_mock() -> None:
 
     wrapper = IMUWrapper(
         config=config,
-        imu_descriptor=IMUDescriptor(name="MOCK", index=0),
+        imu_descriptor=IMUDescriptor(name=name, index=0),
         i2c_bus_descriptor=I2CBusDescriptor(None, None),
     )
     imu = MagicMock()
@@ -296,7 +298,7 @@ def test_pre_config_with_mock() -> None:
 def test_pre_config_string():
     """Test if the IMU is pre-configured properly with a string argument."""
     # Arrange
-    config = IMUDevices.MOCK.config
+    name, config = get_mock()
     config = mutate_sensor(
         cfg=config,
         device_id=IMUDeviceID.IMU0,
@@ -309,7 +311,7 @@ def test_pre_config_string():
 
     wrapper = IMUWrapper(
         config=config,
-        imu_descriptor=IMUDescriptor(name="MOCK", index=0),
+        imu_descriptor=IMUDescriptor(name=name, index=0),
         i2c_bus_descriptor=I2CBusDescriptor(None, None),
     )
 
@@ -323,7 +325,7 @@ def test_pre_config_string():
 def test_pre_config_time_sleep():
     """Test if time.sleep can be called in pre-configuration."""
     # Arrange
-    config = IMUDevices.MOCK.config
+    name, config = get_mock()
     config = mutate_sensor(
         cfg=config,
         device_id=IMUDeviceID.IMU0,
@@ -336,7 +338,7 @@ def test_pre_config_time_sleep():
 
     wrapper = IMUWrapper(
         config=config,
-        imu_descriptor=IMUDescriptor(name="MOCK", index=0),
+        imu_descriptor=IMUDescriptor(name=name, index=0),
         i2c_bus_descriptor=I2CBusDescriptor(None, None),
     )
 
@@ -395,7 +397,7 @@ def test_vectorize_parametrized(value, expected) -> None:
 def test_apply_mag_calibration() -> None:
     """Test if magnetometer calibration is applied correctly."""
     # Arrange
-    config = IMUDevices.MOCK.config
+    name, config = get_mock()
     config.roles.update({IMUSensorTypes.mag: IMUDeviceID.IMU0})
     mag_calibration = (
         np.array([1.0, 2.0, 3.0]),
@@ -403,7 +405,7 @@ def test_apply_mag_calibration() -> None:
     )
     wrapper = IMUWrapper(
         config=config,
-        imu_descriptor=IMUDescriptor(name="MOCK", index=0),
+        imu_descriptor=IMUDescriptor(name=name, index=0),
         i2c_bus_descriptor=I2CBusDescriptor(None, None),
     )
     wrapper.mag_calibration = mag_calibration

--- a/uv.lock
+++ b/uv.lock
@@ -644,7 +644,7 @@ wheels = [
 
 [[package]]
 name = "imu-python"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "ahrs" },


### PR DESCRIPTION
# Summary
Describe the main changes in this PR:
- Added a registry that registers all IMU devices in `[project.entry-points."imu_module.devices"]` and adds them to a dict called `IMU_DEVICES`.
- The old Enum class `IMUDevices` no longer exists. The methods that match the addresses to devices are now standalone.
- This structure allows projects downstream to add their own IMUs or modify the settings of existing IMUs without forking/modifying this module, by adding to their `pyproject.toml`.
- The existing configs are now in the `builtin_devices.py` file to avoid circular import.
---

# Code Quality Checklist
Before requesting review, ensure:
- [x] All CI/CD pipelines pass
- [x] Code includes docstrings and type hints
- [ ] I added new tests where necessary
- [x] I ran **`make tree`** to update the README.md
---

# Additional Notes
- Anything else reviewers should know?
- Attach outputs, plots, logs, or GIFs here.
